### PR TITLE
Detect if we are sending Template output to a TTY or not

### DIFF
--- a/bupy/cli.py
+++ b/bupy/cli.py
@@ -211,9 +211,12 @@ def template(
     with util.SilenceTemplateException():
         if show:
             bu = tpl.rendered_template(template, tpl.read_template_vars(variables)).decode("utf-8")
-            syntax = Syntax(bu, "YAML", line_numbers=line_numbers)
-            console = Console(color_system=None)
-            console.print(syntax)
+            if sys.stdout.isatty():
+                syntax = Syntax(bu, "YAML", line_numbers=line_numbers)
+                console = Console(color_system=None)
+                console.print(syntax)
+            else:
+                print(bu)
             raise typer.Exit()
 
         # TODO: Add support for finding bupyvars.yaml file in CWD, or in the directory the template resides in.

--- a/bupy/cli.py
+++ b/bupy/cli.py
@@ -89,7 +89,10 @@ def vm(
         show_default=False,
     ),
     template: str = typer.Option(
-        "", "--template", "-t", help="Read file as a Jinja2 template and load a variables file."
+        "",
+        "--template",
+        "-t",
+        help="Read file as a Jinja2 template and load a variables file.\n(--template bupyvars.yaml template.bu.j2)",
     ),
     write: str = typer.Option("", "--write", "-w", help="Write the Ignition JSON to a file."),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite an existing Ignition file."),


### PR DESCRIPTION
This PR will detect if we are trying to output a butane template do not use Rich Syntax features if we are sending data to a pipe or redirecting.