### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
+# CHANGELOG
+
+## 0.1.2
+
+* Update Typer to 0.9.0 and Rich to 13.4.2.
+
+IMPROVEMENTS:
+
+* Add support for static port maps when launching a VM with QEMU. See bupy vm --help for more info.
+* Check for DISPLAY in the env and set -display none on QEMU if running on a headless server.
+* Detect if we are sending Template output to a TTY or not
+
 ## 0.1.1
 
 IMPROVEMENTS:
+
 * Python 3.8.10^ support.
 
 ## 0.1.0
-* Initial release! 
+
+* Initial release!

--- a/bupy/__init__.py
+++ b/bupy/__init__.py
@@ -1,2 +1,2 @@
 __app_name__ = "bupy"
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bupy"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python toolkit for Butane and Ignition"
 authors = ["QuickVM <hello@quickvm.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,10 @@ packages = ["bupy"]
 
 package_data = {"": ["*"]}
 
-install_requires = [
-    "Jinja2>=3.1.2,<4.0.0",
-    "pyxdg>=0.28,<0.29",
-    "rich>=12.5.1,<13.0.0",
-    "ruamel.yaml>=0.17.21,<0.18.0",
-    "typer[all]>=0.6.1,<0.7.0",
-    "urllib3>=1.26.10,<2.0.0",
-]
+with open("requirements.txt") as f:
+    required = f.read().splitlines()
+
+install_requires = required
 
 entry_points = {"console_scripts": ["bupy = bupy.cli:app"]}
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ entry_points = {"console_scripts": ["bupy = bupy.cli:app"]}
 
 setup_kwargs = {
     "name": "bupy",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "A Python toolkit for Butane and Ignition",
     "author": "QuickVM",
     "author_email": "hello@quickvm.com",

--- a/tests/test_bupy.py
+++ b/tests/test_bupy.py
@@ -2,4 +2,4 @@ from bupy import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.1"
+    assert __version__ == "0.1.2"


### PR DESCRIPTION
Release 0.1.2

* Update Typer to 0.9.0 and Rich to 13.4.2.

IMPROVEMENTS:

* Add support for static port maps when launching a VM with QEMU. See bupy vm --help for more info.
* Check for DISPLAY in the env and set -display none on QEMU if running on a headless server.
* Detect if we are sending Template output to a TTY or not

